### PR TITLE
Rename logstash-grokfail index to grokfail

### DIFF
--- a/sources/syslog/output.conf
+++ b/sources/syslog/output.conf
@@ -13,7 +13,7 @@ output {
     } else {
       elasticsearch {
         hosts               => [ "elasticsearch" ]
-        index               => "logstash-grokfail-%{+YYYY.MM.dd}"
+        index               => "grokfail-%{+YYYY.MM.dd}"
         flush_size          => 100
         manage_template     => false
       }


### PR DESCRIPTION
This prevents grokfail events from matching logstash-* index patterns