### PR TITLE
Fix failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CISE-ELK
 
+[![Build Status](https://travis-ci.org/sohonetlabs/cise-elk.svg?branch=master)](https://travis-ci.org/sohonetlabs/cise-elk)
+
 ## Overview
 
 This repository contains all the logstash and pmacctd configs, elasticsearch index templates, kibana dashboards and elastalert alerting rules created for the CISE project. It represents an entire configured ELK stack which can be used to record and report on security relevant events for your infrastructure.

--- a/sources/syslog/filter.conf
+++ b/sources/syslog/filter.conf
@@ -9,7 +9,6 @@ filter{
         ]
       }
       patterns_dir => "/etc/logstash/patterns"
-      remove_field => [ "syslog_program", "syslog_hostname", "syslog_pri", "syslog_pid" ]
       named_captures_only => true
       remove_tag => ["_grokparsefailure"]
       break_on_match => true
@@ -21,7 +20,7 @@ filter{
 
 # Grok Filter for SSH Invalid User
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -30,7 +29,6 @@ filter {
         ]
       }
       patterns_dir => "/etc/logstash/patterns"
-      remove_field => [ "syslog_program", "syslog_hostname", "syslog_pri", "syslog_pid" ]
       named_captures_only => true
       remove_tag => ["_grokparsefailure"]
       break_on_match => true
@@ -42,7 +40,7 @@ filter {
 
 # Grok Filter for Sudo Auth Failure
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -51,7 +49,6 @@ filter {
         ]
       }
       patterns_dir => "/etc/logstash/patterns"
-      remove_field => [ "syslog_program", "syslog_hostname", "syslog_pri", "syslog_pid" ]
       named_captures_only => true
       remove_tag => ["_grokparsefailure"]
       break_on_match => true
@@ -63,7 +60,7 @@ filter {
 
 filter {
 # Grok Filter for SSH Password Accepted
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -72,7 +69,6 @@ filter {
         ]
       }
       patterns_dir => "/etc/logstash/patterns"
-      remove_field => [ "syslog_program", "syslog_hostname", "syslog_pri", "syslog_pid" ]
       named_captures_only => true
       remove_tag => ["_grokparsefailure"]
       break_on_match => true
@@ -84,7 +80,7 @@ filter {
 
 # Grok Filter for SSH Public Key Accepted
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -93,7 +89,6 @@ filter {
         ]
       }
       patterns_dir => "/etc/logstash/patterns"
-      remove_field => [ "syslog_program", "syslog_hostname", "syslog_pri", "syslog_pid" ]
       named_captures_only => true
       remove_tag => ["_grokparsefailure"]
       break_on_match => true
@@ -105,7 +100,7 @@ filter {
 
 # Grok Filter for Junos IDP Logs
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -126,7 +121,7 @@ filter {
 
 # Grok Filter for tripwire Logs
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -135,7 +130,6 @@ filter {
         ]
       }
       patterns_dir => "/etc/logstash/patterns"
-      remove_field => [ "syslog_program", "syslog_hostname", "syslog_pri", "syslog_pid" ]
       named_captures_only => true
       remove_tag => ["_grokparsefailure"]
       break_on_match => true
@@ -156,7 +150,7 @@ filter {
 
 # Grok Filter for UNIFI Devices
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -177,7 +171,7 @@ filter {
 
 # Grok Filter for ScreenOS Devices
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
 
     grok {
       match => {
@@ -198,7 +192,7 @@ filter {
 
 # Squid Access Logs
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
     grok {
       match => {
         "message" => [
@@ -240,7 +234,7 @@ filter {
 
 #Sonicwall Filter
 filter {
-  if ( [type] == "syslog" ) {
+  if ( [type] == "syslog" and "_grokparsefailure" in [tags]) {
     grok {
       match => {
         "message" => [

--- a/sources/syslog/filter.conf
+++ b/sources/syslog/filter.conf
@@ -218,12 +218,13 @@ filter {
 
   if ( "squid_access_log" in [tags]) {
     if ( "" in [request]){
-      	grok {
-      	match => {
-        	"request" => [ "(?:%{URIPROTO:uriproto}://)?(?:%{USER:uriuser}(?::[^@]*)?@)?(?:%{IPORHOST:urihost}(?::%{POSINT:port})?)?(?:%{URIPATHPARAM:uripathparm})?" ]
-      	}
-      	break_on_match => true
-    	}
+      grok {
+        match => {
+          "request" => [ "(?:%{URIPROTO:uriproto}://)?(?:%{USER:uriuser}(?::[^@]*)?@)?(?:%{IPORHOST:urihost}(?::%{POSINT:port})?)?(?:%{URIPATHPARAM:uripathparm})?" ]
+        }
+        break_on_match => true
+        remove_tag => ["_grokparsefailure"]
+      }
     }
 
     # Extract second level domain from urihost

--- a/tests/syslog_ssh_failed_password.json
+++ b/tests/syslog_ssh_failed_password.json
@@ -8,7 +8,6 @@
     "in": "<38>Sep  6 09:36:57 systemhostname sshd[10031]: Failed password for root from 45.249.90.40 port 48736 ssh2",
     "out": {
       "type": "syslog",
-      "syslog_message": "Failed password for root from 45.249.90.40 port 48736 ssh2",
       "syslog_pri": "38",
       "syslog_program": "sshd",
       "syslog_hostname": "systemhostname",

--- a/tests/syslog_ssh_invalid_user.json
+++ b/tests/syslog_ssh_invalid_user.json
@@ -8,7 +8,6 @@
     "in": "<38>Sep  6 09:36:57 systemhostname sshd[10031]: Failed password for invalid user admin from 185.93.185.7 port 49574 ssh2",
     "out": {
       "type": "syslog",
-      "syslog_message": "Failed password for invalid user admin from 185.93.185.7 port 49574 ssh2",
       "syslog_pri": "38",
       "syslog_program": "sshd",
       "syslog_hostname": "systemhostname",


### PR DESCRIPTION
Tests were failing for squid logs:

       [squid_access_log.json#0] Unexpected fields in logstash output: ["syslog_message"]

This is because the generic syslog grok pattern is matching as well as the squid access pattern.

This PR updates the logic and tests to only match a single grok pattern in the syslog filter configuration.